### PR TITLE
Add pytz to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     packages=['handy', 'handy.forms', 'handy.models'],
     install_requires=[
         'django>=1.2',
+        'pytz==2012j',
     ],
 
     classifiers=[


### PR DESCRIPTION
Hi! I am receiving an error message while trying to import `handy.ajax`. In it says that `pytz` module was not found. In pull request I am add `pytz` module into requirements.

p.s. Sorry for my english
