### PR TITLE
Update with python 3 compatible syntax.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
-python: 2.7
+python:
+  - 2.7
+  - 3.3
+  - 3.4
 install:
   - pip install -r test_requirements.txt
 before_script:

--- a/handy/ajax.py
+++ b/handy/ajax.py
@@ -30,7 +30,7 @@ class Ajax(object):
                 if isinstance(data, HttpResponse):
                     return data
                 return {'success': True, 'data': data}
-            except self.error, e:
+            except self.error as e:
                 return e.params
         return render_to_json(default=encode_object)(wrapper)
 
@@ -43,7 +43,7 @@ class Ajax(object):
                     return func(*args, **kwargs)
                 except self.error:
                     raise
-                except exceptions, e:
+                except exceptions as e:
                     error_name = camel_to_underscores(e.__class__.__name__)
                     error_text = e.args[0] if e.args else ''
                     raise self.error(error_name, error_text=error_text)

--- a/handy/db.py
+++ b/handy/db.py
@@ -89,7 +89,7 @@ def fetch_dict(sql, params=(), server='default'):
 def fetch_named(sql, params=(), server='default'):
     with db_execute(sql, params, server) as cursor:
         rec_class = _row_namedtuple(cursor)
-        return map(rec_class._make, cursor.fetchall())
+        return [rec_class._make(row) for row in cursor.fetchall()]
 
 def fetch_named_row(sql, params=(), server='default'):
     with db_execute(sql, params, server) as cursor:
@@ -101,7 +101,7 @@ def _row_namedtuple(cursor):
     return namedtuple('TableRow', _field_names(cursor))
 
 def _field_names(cursor):
-    return map(itemgetter(0), cursor.description)
+    return [name[0] for name in cursor.description]
 
 
 def silent_first(seq):

--- a/handy/http.py
+++ b/handy/http.py
@@ -21,7 +21,7 @@ def raw_pipeline(domain, pages, max_out_bound=4, method='GET', timeout=None, deb
                 break
             elif page and not finished[i] and respobjs[i] is None:
                 if debuglevel > 0:
-                    print 'Sending request for %r...' % (page,)
+                    print('Sending request for %r...' % (page,))
                 conn._HTTPConnection__state = _CS_IDLE # FU private variable!
                 conn.request(method, page, None, headers)
                 respobjs[i] = conn.response_class(conn.sock, strict=conn.strict, method=conn._method)
@@ -32,12 +32,12 @@ def raw_pipeline(domain, pages, max_out_bound=4, method='GET', timeout=None, deb
             if resp is None:
                 continue
             if debuglevel > 0:
-                print 'Retrieving %r...' % (pages[i],)
+                print('Retrieving %r...' % (pages[i],))
             out_bound -= 1
             skip_read = False
             resp.begin()
             if debuglevel > 0:
-                print '    %d %s' % (resp.status, resp.reason)
+                print('    %d %s' % (resp.status, resp.reason))
             if 200 <= resp.status < 300:
                 # Ok
                 data[i] = resp.read()
@@ -64,7 +64,7 @@ def raw_pipeline(domain, pages, max_out_bound=4, method='GET', timeout=None, deb
                 else:
                     path = urlparse.urlunparse(parsed._replace(scheme='',netloc='',fragment=''))
                     if debuglevel > 0:
-                        print '  Updated %r to %r' % (pages[i],path)
+                        print('  Updated %r to %r' % (pages[i],path))
                     pages[i] = path
             elif resp.status >= 400:
                 # Failed
@@ -76,11 +76,11 @@ def raw_pipeline(domain, pages, max_out_bound=4, method='GET', timeout=None, deb
                 # Connection (will be) closed, need to resend
                 conn.close()
                 if debuglevel > 0:
-                    print '  Connection closed'
+                    print('  Connection closed')
                 for j, f in enumerate(finished):
                     if not f and respobjs[j] is not None:
                         if debuglevel > 0:
-                            print '  Discarding out-bound request for %r' % (pages[j],)
+                            print('  Discarding out-bound request for %r' % (pages[j],))
                         respobjs[j] = None
                 break
             elif not skip_read:
@@ -149,6 +149,6 @@ if __name__ == '__main__':
     pages = ('/wiki/HTTP_pipelining', '/wiki/HTTP', '/wiki/HTTP_persistent_connection')
     data = raw_pipeline(domain, pages, debuglevel=1, method='HEAD', max_out_bound=6, timeout=1)
     for i,page in enumerate(data):
-        print
-        print '==== Page %r ====' % (pages[i],)
+        print()
+        print('==== Page %r ====' % (pages[i],))
         #print page[:512]

--- a/handy/mail.py
+++ b/handy/mail.py
@@ -69,10 +69,10 @@ def render_to_email(email, template_name, data=None, request=None, from_email=No
         pass
 
     if settings.DEBUG:
-        print u'To: %s' % ', '.join(message.to)
-        print u'From: %s' % message.from_email
-        print u'Subject: %s' % message.subject
-        print message.body
+        print(u'To: %s' % ', '.join(message.to))
+        print(u'From: %s' % message.from_email)
+        print(u'Subject: %s' % message.subject)
+        print(message.body)
 
 
 def mail_admins(subject, message='', trace=True):

--- a/handy/utils.py
+++ b/handy/utils.py
@@ -52,7 +52,7 @@ def get_module_attr(path):
     try:
         mod = import_module(module)
         return getattr(mod, attr, None)
-    except ImportError, e:
+    except ImportError as e:
         return None
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,12 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
 
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+
         'Framework :: Django',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Test against python 3.3 and 3.4 on travis.

One change is to use list comprehension rather than map,
as map returns an iterator in python 3. This is more
efficient than doing list(map(...)) which creates an
additional copy in python 2.